### PR TITLE
Removed root access and added some more features

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -65,18 +65,24 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/debug" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/coverage-instrumented-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaResources" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/libs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/ndk" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/release" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/proguard" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,14 +2,14 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "com.arilotter.xposedsettingsinjector"
         minSdkVersion 21
         targetSdkVersion 23
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.1.0"
     }
     buildTypes {
         release {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,11 +1,14 @@
 <manifest
     package="com.arilotter.xposedsettingsinjector"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"
+        android:fullBackupContent="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name">
+        android:label="@string/app_name"
+        tools:ignore="UnusedAttribute">
         <meta-data
             android:name="xposedmodule"
             android:value="true"/>
@@ -15,6 +18,27 @@
         <meta-data
             android:name="xposeddescription"
             android:value="@string/xposed_description"/>
+
+        <activity
+            android:name=".SettingsActivity"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="de.robv.android.xposed.category.MODULE_SETTINGS"/>
+            </intent-filter>
+        </activity>
+
+        <activity-alias
+            android:name=".SettingsAlias"
+            android:enabled="true"
+            android:label="@string/app_name"
+            android:targetActivity=".SettingsActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity-alias>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/arilotter/xposedsettingsinjector/ModuleLoader.java
+++ b/app/src/main/java/com/arilotter/xposedsettingsinjector/ModuleLoader.java
@@ -6,23 +6,45 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 
 public class ModuleLoader {
+
     @SuppressLint("SdCardPath")
     private static final String MODULES_LIST_FILE = "/data/data/de.robv.android.xposed.installer/conf/modules.list";
+    private static final String PUBLIC_MODULES_LIST_FILE = "/storage/emulated/0/XposedSettingsInjector/modules.list";
+
     private static final String SETTINGS_CATEGORY = "de.robv.android.xposed.category.MODULE_SETTINGS";
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    static void copyModulesListToSd() throws IOException {
+        File src = new File(MODULES_LIST_FILE);
+        File dst = new File(PUBLIC_MODULES_LIST_FILE);
+        if (!dst.exists()) {
+            dst.getParentFile().mkdir();
+            dst.createNewFile();
+        }
+        FileInputStream in = new FileInputStream(src);
+        FileOutputStream out = new FileOutputStream(dst);
+        byte[] buf = new byte[1024];
+        int len;
+        while ((len = in.read(buf)) > 0) {
+            out.write(buf, 0, len);
+        }
+        in.close();
+        out.close();
+    }
 
     /* Taken from Xposed Installer */
     static Intent getSettingsIntent(PackageManager pm, String packageName) {
-        // taken from
-        // ApplicationPackageManager.getLaunchIntentForPackage(String)
-        // first looks for an Xposed-specific category, falls back to
-        // getLaunchIntentForPackage
+        // taken from ApplicationPackageManager.getLaunchIntentForPackage(String)
+        // first looks for an Xposed-specific category, falls back to getLaunchIntentForPackage
 
         Intent intentToResolve = new Intent(Intent.ACTION_MAIN);
         intentToResolve.addCategory(SETTINGS_CATEGORY);
@@ -39,50 +61,15 @@ public class ModuleLoader {
         return intent;
     }
 
-    static List<String> getActiveModulesWithSu() {
+    static List<String> getActiveModulesFromSd() throws IOException {
         List<String> modules = new ArrayList<>();
-//        try {
-//            String line;
-//
-//            BufferedReader br = new BufferedReader(new FileReader(MODULES_LIST_FILE));
-//            while ((line = br.readLine()) != null) {
-//                modules.add(line);
-//                log("Settings: Found Module: " + line);
-//            }
-//            br.close();
-//        } catch (IOException e) {
-//            throw new RuntimeException(e);
-//        }
-        // TODO read this file better
-        Process process;
-        try {
-            String line;
-            process = new ProcessBuilder("su", "-c", "cat", MODULES_LIST_FILE).start();
-
-            BufferedReader in = new BufferedReader(new InputStreamReader(process.getInputStream()));
-            while ((line = in.readLine()) != null) {
-                modules.add(line);
-            }
-            in.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        String line;
+        BufferedReader br = new BufferedReader(new FileReader(PUBLIC_MODULES_LIST_FILE));
+        while ((line = br.readLine()) != null) {
+            modules.add(line);
         }
+        br.close();
         return modules;
     }
 
-    static List<String> getActiveModules() {
-        List<String> modules = new ArrayList<>();
-        try {
-            String line;
-
-            BufferedReader br = new BufferedReader(new FileReader(MODULES_LIST_FILE));
-            while ((line = br.readLine()) != null) {
-                modules.add(line);
-            }
-            br.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return modules;
-    }
 }

--- a/app/src/main/java/com/arilotter/xposedsettingsinjector/ModuleLoader.java
+++ b/app/src/main/java/com/arilotter/xposedsettingsinjector/ModuleLoader.java
@@ -71,12 +71,13 @@ public class ModuleLoader {
 
     static List<String> getActiveModulesFromSd() throws IOException {
         List<String> modules = new ArrayList<>();
-        if (!new File(PUBLIC_MODULES_LIST_FILE).exists()) {
+        File publicFile = new File(PUBLIC_MODULES_LIST_FILE);
+        if (!publicFile.exists()) {
             XposedBridge.log("[XposedSettingsInjector] No public copy of modules.list found!");
             return modules;
         }
         String line;
-        BufferedReader br = new BufferedReader(new FileReader(PUBLIC_MODULES_LIST_FILE));
+        BufferedReader br = new BufferedReader(new FileReader(publicFile));
         while ((line = br.readLine()) != null) {
             modules.add(line);
         }

--- a/app/src/main/java/com/arilotter/xposedsettingsinjector/ModuleLoader.java
+++ b/app/src/main/java/com/arilotter/xposedsettingsinjector/ModuleLoader.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import de.robv.android.xposed.XposedBridge;
+
 public class ModuleLoader {
 
     @SuppressLint("SdCardPath")
@@ -26,9 +28,15 @@ public class ModuleLoader {
     static void copyModulesListToSd() throws IOException {
         File src = new File(MODULES_LIST_FILE);
         File dst = new File(PUBLIC_MODULES_LIST_FILE);
+        if (!src.exists()) {
+            XposedBridge.log("[XposedSettingsInjector] No modules.list found!");
+            return;
+        }
         if (!dst.exists()) {
-            dst.getParentFile().mkdir();
+            dst.getParentFile().mkdirs();
             dst.createNewFile();
+            dst.setReadable(true, false);
+            dst.setWritable(true, false);
         }
         FileInputStream in = new FileInputStream(src);
         FileOutputStream out = new FileOutputStream(dst);
@@ -63,6 +71,10 @@ public class ModuleLoader {
 
     static List<String> getActiveModulesFromSd() throws IOException {
         List<String> modules = new ArrayList<>();
+        if (!new File(PUBLIC_MODULES_LIST_FILE).exists()) {
+            XposedBridge.log("[XposedSettingsInjector] No public copy of modules.list found!");
+            return modules;
+        }
         String line;
         BufferedReader br = new BufferedReader(new FileReader(PUBLIC_MODULES_LIST_FILE));
         while ((line = br.readLine()) != null) {

--- a/app/src/main/java/com/arilotter/xposedsettingsinjector/SettingsActivity.java
+++ b/app/src/main/java/com/arilotter/xposedsettingsinjector/SettingsActivity.java
@@ -1,0 +1,62 @@
+package com.arilotter.xposedsettingsinjector;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.preference.PreferenceFragment;
+
+import java.io.File;
+
+public class SettingsActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        getFragmentManager().beginTransaction().replace(android.R.id.content, new Fragment()).commit();
+    }
+
+    public static class Fragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+        @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            //noinspection deprecation
+            getPreferenceManager().setSharedPreferencesMode(Context.MODE_WORLD_READABLE);
+            addPreferencesFromResource(R.xml.preferences);
+        }
+
+        @Override
+        public void onSharedPreferenceChanged(SharedPreferences prefs, String key) {
+            switch (key) {
+                case "hide_launcher_icon":
+                    int mode = prefs.getBoolean("hide_launcher_icon", false) ? PackageManager.COMPONENT_ENABLED_STATE_DISABLED : PackageManager.COMPONENT_ENABLED_STATE_ENABLED;
+                    getActivity().getPackageManager().setComponentEnabledSetting(new ComponentName(getActivity(), "com.arilotter.xposedsettingsinjector.SettingsAlias"), mode, PackageManager.DONT_KILL_APP);
+                    break;
+            }
+        }
+
+        @Override
+        public void onResume() {
+            super.onResume();
+            getPreferenceManager().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+        }
+
+        @Override
+        public void onPause() {
+            super.onPause();
+            // Just to be sure
+            getPreferenceManager().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
+            File sharedPrefsDir = new File(getActivity().getFilesDir(), "../shared_prefs");
+            File sharedPrefsFile = new File(sharedPrefsDir, getPreferenceManager().getSharedPreferencesName() + ".xml");
+            if (sharedPrefsFile.exists()) {
+                //noinspection ResultOfMethodCallIgnored
+                sharedPrefsFile.setReadable(true, false);
+            }
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/arilotter/xposedsettingsinjector/SettingsActivity.java
+++ b/app/src/main/java/com/arilotter/xposedsettingsinjector/SettingsActivity.java
@@ -47,8 +47,8 @@ public class SettingsActivity extends Activity {
         @Override
         public void onPause() {
             super.onPause();
-            // Just to be sure
             getPreferenceManager().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
+            // Just to be sure
             File sharedPrefsDir = new File(getActivity().getFilesDir(), "../shared_prefs");
             File sharedPrefsFile = new File(sharedPrefsDir, getPreferenceManager().getSharedPreferencesName() + ".xml");
             if (sharedPrefsFile.exists()) {

--- a/app/src/main/java/com/arilotter/xposedsettingsinjector/XposedMod.java
+++ b/app/src/main/java/com/arilotter/xposedsettingsinjector/XposedMod.java
@@ -5,13 +5,23 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.widget.ImageView;
+import android.widget.Switch;
+import android.widget.TextView;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import de.robv.android.xposed.IXposedHookLoadPackage;
+import de.robv.android.xposed.IXposedHookZygoteInit;
 import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XSharedPreferences;
+import de.robv.android.xposed.XposedBridge;
+import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam;
 
 import static de.robv.android.xposed.XposedHelpers.callMethod;
@@ -21,69 +31,152 @@ import static de.robv.android.xposed.XposedHelpers.newInstance;
 import static de.robv.android.xposed.XposedHelpers.setIntField;
 import static de.robv.android.xposed.XposedHelpers.setObjectField;
 
-public class XposedMod implements IXposedHookLoadPackage {
+public class XposedMod implements IXposedHookLoadPackage, IXposedHookZygoteInit {
+
     @SuppressWarnings("unused")
     private static final String TAG = "InjectXposedPreference";
-    private static List<String> activeModules;
+    private XSharedPreferences mPrefs = new XSharedPreferences(XposedMod.this.getClass().getPackage().getName());
+
+    private Class<?> DashboardCategory;
+    private Class<?> DashboardTile;
+
+    @Override
+    public void initZygote(StartupParam startupParam) throws Throwable {
+        ModuleLoader.copyModulesListToSd();
+    }
 
     @Override
     public void handleLoadPackage(final LoadPackageParam lpparam) throws Throwable {
-        if (!lpparam.packageName.equals("com.android.settings"))
-            return;
-        final Class<?> DashboardCategory = findClass("com.android.settings.dashboard.DashboardCategory", lpparam.classLoader);
-        Class<?> SettingsActivity = findClass("com.android.settings.SettingsActivity", lpparam.classLoader);
-        final Class<?> DashboardTile = findClass("com.android.settings.dashboard.DashboardTile", lpparam.classLoader);
+        if (lpparam.packageName.equals("com.android.settings")) {
 
-        // TODO find a way to disable tint?
-//        findAndHookMethod(DashboardSummary, "updateTileView", Context.class, Resources.class, DashboardTile, ImageView.class, TextView.class, TextView.class, new XC_MethodHook() {
-//            @Override
-//            protected void afterHookedMethod(MethodHookParam param) throws Throwable {
-//                ImageView view = ((ImageView) param.args[4]);
-//                Drawable icon = view.getDrawable();
-//                icon.setTintList(null);
-//            }
-//        });
+            Class<?> SettingsActivity = findClass("com.android.settings.SettingsActivity", lpparam.classLoader);
+            Class<?> DashboardSummary = findClass("com.android.settings.dashboard.DashboardSummary", lpparam.classLoader);
+            DashboardCategory = findClass("com.android.settings.dashboard.DashboardCategory", lpparam.classLoader);
+            DashboardTile = findClass("com.android.settings.dashboard.DashboardTile", lpparam.classLoader);
 
-        findAndHookMethod(SettingsActivity, "loadCategoriesFromResource", "int", List.class, Context.class, new XC_MethodHook() {
-            @Override
-            protected void afterHookedMethod(MethodHookParam param) throws Throwable {
-                Context context = (Context) param.args[2];
-                PackageManager pm = context.getPackageManager();
-                ArrayList<ApplicationInfo> xposedModulesList = new ArrayList<ApplicationInfo>();
-                List<String> activeModules = ModuleLoader.getActiveModulesWithSu();
-
-                for (PackageInfo pkg : context.getPackageManager().getInstalledPackages(PackageManager.GET_META_DATA)) {
-                    ApplicationInfo app = pkg.applicationInfo;
-                    boolean isXposedInstaller = app.packageName.equals("de.robv.android.xposed.installer");
-                    if ((!app.enabled || !activeModules.contains(app.sourceDir)) && !isXposedInstaller)
-                        continue;
-
-                    // Always put the Xposed installer in the list.
-                    if ((app.metaData != null && app.metaData.containsKey("xposedmodule")) || isXposedInstaller) {
-                        xposedModulesList.add(app);
-                    }
+            try {
+                findAndHookMethod(DashboardSummary, "updateTileView", Context.class, Resources.class, DashboardTile, ImageView.class, TextView.class, TextView.class, updateTileViewHook);
+            } catch (Throwable t) {
+                try { // CyanogenMod takes an additional Switch parameter
+                    findAndHookMethod(DashboardSummary, "updateTileView", Context.class, Resources.class, DashboardTile, ImageView.class, TextView.class, TextView.class, Switch.class, updateTileViewHook);
+                } catch (Throwable t2) {
+                    XposedBridge.log("[XposedSettingsInjector] Error hooking updateTileView in settings");
+                    XposedBridge.log(t2);
                 }
+            }
 
+            try {
+                if (Build.VERSION.SDK_INT >= 23)
+                    findAndHookMethod(SettingsActivity, "loadCategoriesFromResource", int.class, List.class, Context.class, loadCategoriesFromResourceHook);
+                else
+                    findAndHookMethod(SettingsActivity, "loadCategoriesFromResource", int.class, List.class, loadCategoriesFromResourceHook);
+            } catch (Throwable t) {
+                XposedBridge.log("[XposedSettingsInjector] Error hooking loadCategoriesFromResource in settings");
+                XposedBridge.log(t);
+            }
+
+        } else if (lpparam.packageName.equals("de.robv.android.xposed.installer")) {
+
+            try {
+                findAndHookMethod("de.robv.android.xposed.installer.util.ModuleUtil", lpparam.classLoader, "updateModulesList", boolean.class, new XC_MethodHook() {
+                    @Override
+                    protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+                        ModuleLoader.copyModulesListToSd();
+                    }
+                });
+            } catch (Throwable t) {
+                XposedBridge.log("[XposedSettingsInjector] Error hooking updateModulesList in installer");
+                XposedBridge.log(t);
+            }
+
+        }
+    }
+
+    private XC_MethodHook loadCategoriesFromResourceHook = new XC_MethodHook() {
+        @Override
+        protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+            mPrefs.reload();
+            boolean onlyInstaller = mPrefs.getBoolean("only_installer", false);
+            Context context;
+            if (Build.VERSION.SDK_INT >= 23)
+                context = (Context) param.args[2];
+            else
+                context = (Context) param.thisObject; // Surrounding activity
+            PackageManager pm = context.getPackageManager();
+            ArrayList<ApplicationInfo> xposedModulesList = new ArrayList<>();
+            List<String> activeModules = ModuleLoader.getActiveModulesFromSd();
+            ApplicationInfo installerInfo = null;
+
+            for (PackageInfo pkg : context.getPackageManager().getInstalledPackages(PackageManager.GET_META_DATA)) {
+                ApplicationInfo app = pkg.applicationInfo;
+                boolean isXposedInstaller = app.packageName.equals("de.robv.android.xposed.installer");
+
+                if ((!activeModules.contains(app.sourceDir) || !app.enabled) && !isXposedInstaller)
+                    continue;
+
+                if (!onlyInstaller && app.metaData != null && app.metaData.containsKey("xposedmodule")) {
+                    xposedModulesList.add(app);
+                } else if (isXposedInstaller) {
+                    installerInfo = app;
+                }
+            }
+
+            if (!onlyInstaller)
                 Collections.sort(xposedModulesList, new ApplicationInfo.DisplayNameComparator(pm));
+            if (installerInfo != null)
+                xposedModulesList.add(0, installerInfo); // Always add the Xposed installer as the first item
 
-                Object category = DashboardCategory.newInstance();
-                setObjectField(category, "title", "Xposed");
+            Object category = DashboardCategory.newInstance();
+            setObjectField(category, "title", "Xposed");
+            boolean showDescriptions = mPrefs.getBoolean("show_descriptions", true);
 
-                for (ApplicationInfo info : xposedModulesList) {
-                    Intent intent = ModuleLoader.getSettingsIntent(pm, info.packageName);
-                    if (intent != null) {
-                        Object tile = newInstance(DashboardTile);
-                        setObjectField(tile, "title", pm.getApplicationLabel(info));
+            for (ApplicationInfo info : xposedModulesList) {
+                Intent intent = ModuleLoader.getSettingsIntent(pm, info.packageName);
+                if (intent != null) {
+                    Object tile = newInstance(DashboardTile);
+                    XposedHelpers.setAdditionalInstanceField(tile, "xposed_item", true);
+                    setObjectField(tile, "title", pm.getApplicationLabel(info));
+                    if (showDescriptions) {
+                        if (info.metaData != null && info.metaData.containsKey("xposeddescription"))
+                            setObjectField(tile, "summary", info.metaData.getString("xposeddescription"));
+                    }
+                    if (Build.VERSION.SDK_INT >= 23) {
                         setIntField(tile, "iconRes", info.icon);
                         setObjectField(tile, "iconPkg", info.packageName);
-//                    tile.icon = pm.getApplicationIcon(info);
-                        setObjectField(tile, "intent", intent);
-                        callMethod(category, "addTile", tile);
+                    } else {
+                        XposedHelpers.setAdditionalInstanceField(tile, "icon", pm.getApplicationIcon(info));
                     }
+                    setObjectField(tile, "intent", intent);
+                    callMethod(category, "addTile", tile);
                 }
-                // Add our category to the list of categories
-                ((List) param.args[1]).add(category);
             }
-        });
+            // Add our category to the list of categories
+            //noinspection unchecked
+            ((List) param.args[1]).add(category);
+        }
+    };
+
+    private XC_MethodHook updateTileViewHook = new XC_MethodHook() {
+        @Override
+        protected void afterHookedMethod(XC_MethodHook.MethodHookParam param) throws Throwable {
+            setIconAndTint(param);
+        }
+    };
+
+    private void setIconAndTint(XC_MethodHook.MethodHookParam param) {
+        ImageView view = ((ImageView) param.args[3]);
+        if (Build.VERSION.SDK_INT >= 23) {
+            Object bool = XposedHelpers.getAdditionalInstanceField(param.args[2], "xposed_item");
+            if (bool != null && (boolean) bool) {
+                Drawable icon = view.getDrawable();
+                icon.setTintList(null);
+            }
+        } else {
+            Object icon = XposedHelpers.getAdditionalInstanceField(param.args[2], "icon");
+            if (icon != null) {
+                view.setImageDrawable((Drawable) icon);
+            }
+        }
     }
+
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,13 @@
     <string name="xposed_modules">Xposed Modules</string>
     <string name="xposed_description">Injects Xposed module settings into (close-to) stock Settings app.</string>
 
+    <string name="settings_general_title">General</string>
+    <string name="settings_only_show_installer_title">Only Xposed Installer</string>
+    <string name="settings_only_show_installer">Only show the Xposed installer in the settings</string>
+    <string name="settings_show_descriptions_title">Show descriptions</string>
+    <string name="settings_show_descriptions">Show the Xposed description of the individual modules</string>
+    <string name="settings_app_title">App</string>
+    <string name="settings_hide_launcher_icon_title">Hide launcher icon</string>
+    <string name="settings_hide_launcher_icon">May require launcher restart</string>
+
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <PreferenceCategory
+        android:title="@string/settings_general_title">
+
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="only_installer"
+            android:summary="@string/settings_only_show_installer"
+            android:title="@string/settings_only_show_installer_title"/>
+
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="show_descriptions"
+            android:summary="@string/settings_show_descriptions"
+            android:title="@string/settings_show_descriptions_title"/>
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/settings_app_title">
+
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="hide_launcher_icon"
+            android:summary="@string/settings_hide_launcher_icon"
+            android:title="@string/settings_hide_launcher_icon_title"/>
+
+    </PreferenceCategory>
+
+</PreferenceScreen>


### PR DESCRIPTION
List of changes:
- Removed root access. The file gets copied to the internal storage where the module can easily access it. It gets copied in initZygote and when the Xposed Installer updates the original file.
- Lollipop support
- CyanogenMod support
- Fixed icon tinting
- Added preferences that allow you to:
  - Only show the installer
  - Show the Xposed description in the subtitle
  - Hide the launcher icon
